### PR TITLE
Update pipeline to deploy only on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,40 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  build-and-test:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '22'
-        
+
     - name: Install pnpm
       uses: pnpm/action-setup@v2
       with:
         version: 10
-        
+
     - name: Install dependencies
       run: pnpm install
-      
+
     - name: Run tests
       run: pnpm test:unit:run
-      
+
     - name: Run type check
       run: pnpm check
-      
+
     - name: Build
       run: pnpm build
-      
+
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
-      
+
     - name: Run Playwright tests
       run: pnpm test:acceptance
-      
+
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v4
       if: failure()
@@ -49,9 +49,33 @@ jobs:
         name: playwright-report
         path: playwright-report/
         retention-days: 15
-      
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    # Only deploy on push to main branch
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 10
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build
+      run: pnpm build
+
     - name: Deploy to Cloudflare Workers
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: cloudflare/wrangler-action@v3
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
- Split build-and-deploy job into two separate jobs:
  - build-and-test: Runs on all pushes and PRs to main
  - deploy: Only runs on push to main branch
- Deploy job now has explicit dependency on build-and-test job
- Improves clarity and follows CI/CD best practices
- Ensures deployment only happens after successful tests on main branch